### PR TITLE
Add a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# 
-Put a brief description of this documentation repository here. You may also provide the Web URL of the documentation site, e.g. "See the website at http://ioos.github.io/name-of-you-repo/" .
+# NGDAC
+
+This page is a collection of documents and resources describing the NetCDF file specification,
+data provider registration and data set submission processes for contributing real-time and delayed-mode glider data sets to the U.S. IOOS National Glider Data Assembly Center (NGDAC).
+
+See the website at https://ioos.github.io/glider-dac/


### PR DESCRIPTION
Let's add a README that describes this page to disambiguate it from the other one, https://gliders.ioos.us/providers/, that is also created by this repo.